### PR TITLE
removed copyright component from withing privacy policy page since it…

### DIFF
--- a/client/src/pages/PrivacyPolicy.js
+++ b/client/src/pages/PrivacyPolicy.js
@@ -110,7 +110,6 @@ export default function PrivacyPolicy() {
 
             </main>
             <Footer />
-            <Copyright />
         </React.Fragment >
     );
 }


### PR DESCRIPTION
…'s already within the footer component.

copyright was showing twice on page.